### PR TITLE
chore: track release-tags ruleset template

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -5,6 +5,7 @@ JSON templates for [GitHub Branch Rulesets](https://docs.github.com/en/repositor
 ## Files
 
 - **[`main-branch.json`](./main-branch.json)** — protect `main` against direct pushes, force-pushes, and deletion; require PR + CI to pass.
+- **[`release-tags.json`](./release-tags.json)** — protect `v*` release tags from deletion and force-push. Deliberately does **not** restrict _creation_ (so `npm run release` can push new tags); admins get an "always" bypass to fix mistakes.
 
 ## Apply
 

--- a/.github/rulesets/release-tags.json
+++ b/.github/rulesets/release-tags.json
@@ -1,0 +1,19 @@
+{
+  "name": "Protect release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [{ "type": "deletion" }, { "type": "non_fast_forward" }],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
Version-controls the `Protect release tags` ruleset (already applied to the repo): protects `v*` tags from deletion + force-push, **allows creation** so `npm run release` works, admins bypass always.