### PR TITLE
chore: gitignore Apple signing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Apple signing artifacts (provided locally / via CI secret, never committed)
+*.provisionprofile
+*.p12
+*.cer


### PR DESCRIPTION
Ignores `*.provisionprofile`, `*.p12`, and `*.cer` so the MAS provisioning profile and any exported certs/keys stay out of this public repo.

These are build inputs — present locally for `npm run electron:build:mas`, or injected via a CI secret. None of them are needed in the tree, and the profile is environment-specific and expires (June 2027).

Note: a provisioning profile contains only the *public* half of the signing cert (no private key), so this is about repo hygiene, not closing a leak.