### PR TITLE
fix(mas): remove unused Downloads entitlement

### DIFF
--- a/build-resources/entitlements.mas.plist
+++ b/build-resources/entitlements.mas.plist
@@ -12,12 +12,10 @@
     <key>com.apple.security.network.client</key>
     <true/>
 
-    <!-- File access for saving audio exports -->
+    <!-- File access for saving audio exports. Exports go through the native
+         Save panel (powerbox), so user-selected scope is sufficient — the app
+         never writes to the Downloads folder directly. -->
     <key>com.apple.security.files.user-selected.read-write</key>
-    <true/>
-
-    <!-- Downloads folder access -->
-    <key>com.apple.security.files.downloads.read-write</key>
     <true/>
 
     <!-- Required for Electron/ONNX runtime -->


### PR DESCRIPTION
## Why

App Store review flagged the MAS build under **guideline 2.4.5(i)** — `com.apple.security.files.downloads.read-write` was declared but has no matching functionality.

## Change

Removes the Downloads entitlement from `entitlements.mas.plist`. Nothing in the app writes to the Downloads folder — audio exports go through the native Save panel (`useAudioPlayer.ts`), which is covered by `files.user-selected.read-write` (still present). The Developer ID build (`entitlements.mac.plist`) already ships without it.