### PR TITLE
build(mas): universal (x86_64 + arm64) App Store package

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -87,6 +87,13 @@
   },
   "mas": {
     "hardenedRuntime": false,
+    "target": [
+      {
+        "target": "pkg",
+        "arch": ["universal"]
+      }
+    ],
+    "x64ArchFiles": "**/onnxruntime-node/bin/**",
     "identity": "Julia Kafarska (8Y2UTZ2NBZ)",
     "provisioningProfile": "build-resources/embedded.provisionprofile",
     "entitlements": "build-resources/entitlements.mas.plist",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "electron:build": "npm run electron-ui:build && npm run electron:compile && electron-builder --publish never",
     "electron:build:mac": "npm run electron-ui:build && npm run electron:compile && electron-builder --mac --publish never -c.directories.output=releases/macos",
     "verify:mas": "node scripts/verify-mas-build.mjs",
-    "electron:build:mas": "npm run electron-ui:build && npm run electron:compile && electron-builder --mac mas --publish never -c.directories.output=releases/macos && npm run verify:mas",
+    "electron:build:mas": "node scripts/build-universal-ffmpeg.mjs && npm run electron-ui:build && npm run electron:compile && electron-builder --mac mas --universal --publish never -c.directories.output=releases/macos && npm run verify:mas",
     "electron:build:mas-dev": "npm run electron-ui:build && npm run electron:compile && electron-builder --mac mas-dev --publish never -c.directories.output=releases/macos",
     "electron:build:win": "node scripts/download-vc-redist.mjs && npm run electron-ui:build && npm run electron:compile && electron-builder --win --publish never -c.directories.output=releases/windows",
     "electron:build:linux": "npm run electron-ui:build && npm run electron:compile && electron-builder --linux --publish never -c.directories.output=releases/linux",

--- a/scripts/build-universal-ffmpeg.mjs
+++ b/scripts/build-universal-ffmpeg.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Make node_modules/ffmpeg-static/ffmpeg a universal (x86_64 + arm64) binary.
+//
+// ffmpeg-static ships a single per-host-arch binary, but the Mac App Store
+// build is universal. @electron/universal skips lipo for binaries that are
+// already fat, so the cleanest fix is to fatten ffmpeg on disk BEFORE the
+// universal MAS build (an arm64-only ffmpeg would otherwise fail the merge,
+// since it'd be an identical single-arch Mach-O in both sub-builds).
+//
+// Idempotent: exits early if ffmpeg is already universal. macOS-only.
+//
+//   node scripts/build-universal-ffmpeg.mjs
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, renameSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+if (process.platform !== "darwin") {
+  console.log("• Not macOS — skipping universal ffmpeg step.");
+  process.exit(0);
+}
+
+const require = createRequire(import.meta.url);
+const ffmpegPath = require("ffmpeg-static");
+const tag = require("ffmpeg-static/package.json")["ffmpeg-static"]["binary-release-tag"];
+
+function archsOf(file) {
+  return execFileSync("lipo", ["-archs", file], { encoding: "utf8" }).trim().split(/\s+/);
+}
+
+const archs = archsOf(ffmpegPath);
+if (archs.includes("x86_64") && archs.includes("arm64")) {
+  console.log(`• ffmpeg already universal (${archs.join(", ")}) — nothing to do.`);
+  process.exit(0);
+}
+
+// ffmpeg-static asset arch names: "x64" / "arm64". lipo reports x86_64/arm64.
+const haveArm = archs.includes("arm64");
+const missingAsset = haveArm ? "ffmpeg-darwin-x64" : "ffmpeg-darwin-arm64";
+const url = `https://github.com/eugeneware/ffmpeg-static/releases/download/${tag}/${missingAsset}`;
+
+console.log(`• ffmpeg is ${archs.join(", ")}-only; fetching ${missingAsset} (${tag})…`);
+const res = await fetch(url);
+if (!res.ok) throw new Error(`Download failed (${res.status}): ${url}`);
+const missingBin = join(tmpdir(), missingAsset);
+writeFileSync(missingBin, Buffer.from(await res.arrayBuffer()));
+
+const merged = join(dirname(ffmpegPath), "ffmpeg.universal");
+execFileSync("lipo", ["-create", ffmpegPath, missingBin, "-output", merged]);
+renameSync(merged, ffmpegPath);
+chmodSync(ffmpegPath, 0o755);
+
+console.log(`• ffmpeg is now universal (${archsOf(ffmpegPath).join(", ")}).`);


### PR DESCRIPTION
The Mac App Store build was arm64-only, so it wouldn't run natively on Intel Macs (which App Store review may use). This makes the MAS build universal.

## Changes
- **electron-builder.json**: `mas` target → `universal`; add `x64ArchFiles` rule so `@electron/universal` keeps onnxruntime's per-arch dylibs as-is (they load by arch at runtime) instead of erroring on identical single-arch files.
- **scripts/build-universal-ffmpeg.mjs** (new): `ffmpeg-static` ships a single host-arch binary; this fattens it into a universal binary before the build. Idempotent, macOS-only.
- **package.json**: `electron:build:mas` runs the ffmpeg step and passes `--universal`.

## Verification
`npm run electron:build:mas` produces `Out Loud-2.1.0-universal.pkg`, verified universal (x86_64 + arm64) across app/framework/helpers/ffmpeg/onnxruntime, signed with Apple Distribution + provisioning profile, App Sandbox on. `verify:mas` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)