### PR TITLE
fix(mas): add application-groups entitlement so the sandboxed app launches

### DIFF
--- a/build-resources/entitlements.mas.plist
+++ b/build-resources/entitlements.mas.plist
@@ -6,6 +6,17 @@
     <key>com.apple.security.app-sandbox</key>
     <true/>
 
+    <!-- Electron talks to its helper processes over a Mach port named
+         <TeamID>.<BundleID>.MachPortRendezvousServer. A sandboxed app may only
+         register that Mach service if the name is covered by an App Group, so
+         without this the app crashes on launch (bootstrap_check_in: Permission
+         denied) before any window appears. Must also be in the provisioning
+         profile. -->
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>8Y2UTZ2NBZ.io.out-loud.outloud</string>
+    </array>
+
     <!-- Outgoing connections only (telemetry, update checks). The local
          extension HTTP server (which would need network.server) is disabled in
          the Mac App Store build per guideline 2.4.5(i). -->

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "io.out-loud.outloud",
   "productName": "Out Loud",
-  "buildVersion": "2.1.0",
+  "buildVersion": "2.1.1",
   "directories": {
     "output": "releases/desktop",
     "buildResources": "build-resources"


### PR DESCRIPTION
## Problem
The Mac App Store build crashed on launch (Apple guideline **2.1(a)** — no window or menu bar item appeared). 

## Root cause
Electron communicates with its helper processes over a Mach service named `<TeamID>.<BundleID>.MachPortRendezvousServer`. A sandboxed app can only register that service if the name is covered by an App Group. The MAS entitlements were missing `com.apple.security.application-groups`, so the main process aborted at startup:
```
FATAL mach_port_rendezvous_mac.cc: bootstrap_check_in
8Y2UTZ2NBZ.io.out-loud.outloud.MachPortRendezvousServer: Permission denied (1100)
```
…before creating any UI.

## Fix
- Add `com.apple.security.application-groups` = `8Y2UTZ2NBZ.io.out-loud.outloud` (the app-identifier form per the [Electron MAS guide](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide)).
- Bump MAS `buildVersion` → 2.1.1 for a fresh App Store Connect upload.

## Verification
Reproduced the crash by ad-hoc re-signing the built app with the sandbox entitlements and launching it (died instantly, exit 133). After adding the entitlement, the same test **launches fully** — main process + GPU/renderer/network helpers spawn and the TTS model loads. `verify:mas` passes; the distribution-signed universal pkg embeds the entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)