### PR TITLE
fix(mas): stop CFBundleVersion drifting from the release version

### DIFF
--- a/docs/build/mac-app-store.md
+++ b/docs/build/mac-app-store.md
@@ -34,6 +34,37 @@ flowchart LR
   ASC --> MAS[Mac App Store]
 ```
 
+## Versioning (CFBundleVersion)
+
+App Store Connect rejects an upload whose `CFBundleVersion` is not **higher** than the last one it accepted, with a 409:
+
+> This bundle is invalid. The value for key CFBundleVersion […] must contain a higher version than that of the previously uploaded version
+
+Two separate keys are involved:
+
+| Key | Comes from | Meaning |
+| --- | ---------- | ------- |
+| `CFBundleShortVersionString` | `package.json` `version` | Marketing version — what users see |
+| `CFBundleVersion` | electron-builder `buildVersion` | Build number — must strictly increase per upload |
+
+**`buildVersion` is deliberately not set** in [`electron-builder.json`](../../electron-builder.json). Left unset, electron-builder defaults it to the `package.json` version, so the build number tracks the release version automatically and cannot drift.
+
+It used to be hardcoded and hand-bumped, and it drifted twice — first 2.0.1 against a 2.0.2 package.json, then 2.1.1 against 2.1.2, which produced exactly the 409 above even though the release had been bumped. `npm version` only edits `package.json`, so any hardcoded value goes stale the moment you cut a release. Don't reintroduce it.
+
+The one legitimate use is **re-uploading under a version App Store Connect has already seen** — a rejected binary, say. Marketing versions don't have to be burned for that: temporarily set a four-component build number and remove it once accepted.
+
+```jsonc
+// electron-builder.json — temporary, for a re-upload of an already-uploaded 2.1.2
+"buildVersion": "2.1.2.1"
+```
+
+Verify before uploading:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" \
+  "releases/macos/mas-universal/Out Loud.app/Contents/Info.plist"
+```
+
 ## Commands
 
 ```bash

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "io.out-loud.outloud",
   "productName": "Out Loud",
-  "buildVersion": "2.1.1",
   "directories": {
     "output": "releases/desktop",
     "buildResources": "build-resources"


### PR DESCRIPTION
Found while building the 2.1.2 MAS package: it would have been rejected by App Store Connect with the **same 409** that rejected the previous upload, despite the version having been bumped.

## Cause

`electron-builder.json` hardcoded `"buildVersion": "2.1.1"`, which sets macOS `CFBundleVersion`. `npm version` only edits `package.json`, so the hardcoded value goes stale the moment a release is cut. The 2.1.2 build came out as:

```
CFBundleShortVersionString: 2.1.2   <- bumped
CFBundleVersion:            2.1.1   <- stale, and this is the key Apple checks
```

App Store Connect requires `CFBundleVersion` to be strictly higher than the last accepted upload. Since 2.1.1 had already been accepted, the 2.1.2 package would have 409'd identically — the kind of failure where bumping the version *looks* like the fix but changes nothing.

This has happened before: d7a7f76's own commit message notes the two values "had drifted" (2.0.1 vs 2.0.2) and realigned them by hand. Hand-maintaining a second version number that must track the first is the bug.

## Fix

Remove the field. Left unset, electron-builder defaults `buildVersion` to the `package.json` version, so the build number tracks the marketing version automatically and cannot drift.

Documented in `mac-app-store.md`, including the one legitimate use: a re-upload under a version App Store Connect has already seen (a rejected binary, say) doesn't need to burn a marketing version — set a temporary four-component build number like `2.1.2.1` and remove it once accepted. Plus the one-liner to check the value before uploading.

The comment couldn't live in `electron-builder.json` itself — it's schema-validated and rejects unknown keys, including `_comment`-style ones.

## Verification

Rebuilt the universal MAS package after the change:

```
CFBundleVersion:            2.1.2
CFBundleShortVersionString: 2.1.2
arch:                       x86_64 arm64
```

`verify:mas` fully green, and the crash logging from #41 is confirmed present in the shipped `app.asar`.

## Note on the published 2.1.2

The already-published direct-download macOS builds carry `CFBundleVersion` 2.1.1 with `CFBundleShortVersionString` 2.1.2. That's cosmetic for Developer ID distribution — Finder and the app both surface the short version string, and updates key off the GitHub release tag — so it isn't worth re-cutting. It self-corrects on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)