### PR TITLE
chore: add CODEOWNERS so reviews must come from the maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Every path in this repository is owned by the maintainer.
+#
+# Paired with "Require review from Code Owners" on `main`, this makes approval
+# specifically @julia-kafarska's rather than any account with write access —
+# so the rule still holds if collaborators are added later.
+#
+# Outside contributions arrive as pull requests from forks (the repo is public
+# and forking is enabled); this is what gates them on a maintainer review.
+#
+# The release automation merges with `gh pr merge --admin`, which bypasses this
+# by design — see docs/build/releasing.md.
+
+* @julia-kafarska


### PR DESCRIPTION
Groundwork for opening the repo to outside contributions.

With **Require review from Code Owners** enabled on `main`, an approving review has to be @julia-kafarska's specifically, rather than any account that happens to have write access. No behaviour change today — you're the sole collaborator — but it keeps "my approval" true if collaborators are ever added, instead of silently degrading to "anyone with write access."

The release automation merges with `gh pr merge --admin` (`scripts/release.mjs`), which bypasses this by design, so `npm run release` is unaffected. That depends on `enforce_admins` staying `false`, which it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)